### PR TITLE
ci: split artifacts per browser and refresh action versions

### DIFF
--- a/.github/workflows/extension-check.yml
+++ b/.github/workflows/extension-check.yml
@@ -1,7 +1,8 @@
 name: Extension check
 
 # Validates the extension on every PR and on pushes to beta, and uploads the
-# candidate zips so a reviewer can load the exact build without checking out.
+# Chrome and Firefox zips as two separate downloads so a reviewer can grab
+# just the one they want without checking the branch out.
 #
 # A version bump touches frontend/app/package.json and both manifest variants,
 # so any PR that bumps the version matches the paths filter and runs this.
@@ -27,12 +28,12 @@ jobs:
         working-directory: frontend/app
 
     steps:
-      # Full history so the PR's version can be compared against the base branch.
-      - uses: actions/checkout@v4
+      # Full history so the PR's version can be compared against its base.
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -49,19 +50,21 @@ jobs:
         id: bump
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          # The PR's base commit, not origin/<base_ref>: a pull_request checkout
+          # lands on the merge commit, where that ref does not reliably point at
+          # the base branch tip.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          git show "origin/$BASE_REF:frontend/app/package.json" > /tmp/base-package.json
+          git show "$BASE_SHA:frontend/app/package.json" > /tmp/base-package.json
           base_version="$(node -p "require('/tmp/base-package.json').version")"
+          echo "base ($BASE_SHA) = $base_version | head = $VERSION"
           if [ "$base_version" = "$VERSION" ]; then
-            echo "bumped=false" >> "$GITHUB_OUTPUT"
             echo "suffix=" >> "$GITHUB_OUTPUT"
             echo "### No version bump — still \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Zips below are a test build, not a release candidate." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "bumped=true" >> "$GITHUB_OUTPUT"
             echo "suffix=-rc" >> "$GITHUB_OUTPUT"
             echo "### Version bump: \`$base_version\` → \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -71,9 +74,19 @@ jobs:
       - name: Build Chrome and Firefox zips
         run: npm run package
 
-      - uses: actions/upload-artifact@v4
+      # One artifact per browser, so each is a separate download.
+      - name: Upload Chrome zip
+        uses: actions/upload-artifact@v7
         with:
-          name: eksiengelplus-${{ steps.meta.outputs.version }}${{ steps.bump.outputs.suffix }}-zips
-          path: frontend/publish/dist/*.zip
+          name: eksiengelplus-${{ steps.meta.outputs.version }}${{ steps.bump.outputs.suffix }}-chrome
+          path: frontend/publish/dist/*-chrome.zip
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Firefox zip
+        uses: actions/upload-artifact@v7
+        with:
+          name: eksiengelplus-${{ steps.meta.outputs.version }}${{ steps.bump.outputs.suffix }}-firefox
+          path: frontend/publish/dist/*-firefox.zip
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -46,7 +46,7 @@ jobs:
         working-directory: frontend/app
         run: npm run package
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: frontend/publish/dist/*.zip
           fail_on_unmatched_files: true


### PR DESCRIPTION
Three fixes to the check workflow, following the first real runs of both workflows on v0.1.2.

- **Two downloads instead of one.** The Chrome and Firefox zips were bundled into a single artifact, so grabbing either meant taking both. They upload separately now.
- **Version-bump detection was wrong.** It compared against `origin/<base_ref>`, which is not reliably the base branch tip — a `pull_request` checkout lands on the merge commit. PR #17 bumped 0.1.0 → 0.1.2 and was still labelled "no bump". Now uses the PR's exact base SHA and echoes both versions to the log.
- **Node 20 deprecation warning.** `checkout`, `setup-node` and `upload-artifact` were on v4; moved to v7. `action-gh-release` v2 → v3, which warned the same way on the v0.1.2 release build.

This PR is itself the test of fix #2: it should be labelled a version bump only if it changes the version. It does not, so expect "No version bump — still 0.1.2" and artifacts without the `-rc` suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)